### PR TITLE
fix: Handle BinderException in type inference fallback logic

### DIFF
--- a/mindsdb/api/executor/utilities/sql.py
+++ b/mindsdb/api/executor/utilities/sql.py
@@ -2,7 +2,7 @@ import copy
 from typing import List
 
 import duckdb
-from duckdb import InvalidInputException
+from duckdb import InvalidInputException, BinderException
 import numpy as np
 
 from mindsdb_sql_parser import parse_sql
@@ -91,7 +91,7 @@ def query_df_with_type_infer_fallback(query_str: str, dataframes: dict, user_fun
                 try:
                     con.execute(f"set global pandas_analyze_sample={sample_size};")
                     result_df = con.execute(query_str).fetchdf()
-                except InvalidInputException as e:
+                except (InvalidInputException, BinderException) as e:
                     exception = e
                 else:
                     break


### PR DESCRIPTION
---

### Description

Please include a summary of the change and the issue it solves.

The type inference fallback mechanism in `query_df_with_type_infer_fallback` was designed to retry queries with a larger sample size upon failure. However, it only caught `InvalidInputException`, failing to handle the common `duckdb.BinderException`.

This exception occurs when the schema inferred from an initial data sample (e.g., `DECIMAL(9,6)`) conflicts with data in a subsequent batch that requires higher precision (e.g., `DECIMAL(10,6)`). This is a frequent issue when performing predictions by joining large datasets where numeric values have a wide range.

By adding `BinderException` to the list of caught exceptions, the retry logic is correctly triggered. This makes the query process more resilient and increases the chances of success on datasets with inconsistent data precision, without requiring users to manually `CAST` column types in their queries.

---

### Type of change

(Please delete options that are not relevant)

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

### Verification Process

To ensure the changes are working as expected:

-   **Test Location**: Local test setup.
-   **Verification Steps**: The fix can be verified by creating a scenario that reliably reproduces the `BinderException`.

    1.  **Create a data source** (e.g., a CSV file named `test_data.csv`) where the precision of a numeric column increases significantly after the default DuckDB sample size (1000 rows).

        **`test_data.csv` example:**
        ```csv
        id,numeric_value
        1,123.456789
        ...
        (repeat the line above for 1000 more rows)
        ...
        1002,98765.432109   // This value requires higher precision (DECIMAL(11,6))
        ```

    2.  **Set up in MindsDB**:
        ```sql
        -- Connect the data file
        -- Create a simple predictor
        CREATE MODEL example_predictor
        FROM example (SELECT * FROM files)
        PREDICT numeric_value;
        ```

    3.  **Run the failing query**:
        ```sql
        SELECT t.id, m.numeric_value
        FROM example.files AS t
        JOIN example_predictor AS m;
        ```

    4.  **Verify the outcome**:
        *   **Without this fix**: The query will fail with a `Binder Error: Contents of view were altered: types don't match!`.
        *   **With this fix**: The query should now succeed. The initial failure triggers the fallback logic, which retries with a larger sample size, correctly infers the `DECIMAL` type, and completes the query.

---

### Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

---

### Checklist:

- [x] My code follows the style guidelines(PEP 8) of MindsDB.
- [x] I have appropriately commented on my code, especially in complex areas. (Note: The change is self-explanatory and small, requiring no additional comments).
- [ ] Necessary documentation updates are either made or tracked in issues. (Note: No documentation update is required for this internal fix).
- [ ] Relevant unit and integration tests are updated or added. (Note: Manual verification process is outlined above. If required, a formal test can be added).